### PR TITLE
Use CPM.cmake for git dependencies (shared, tag-aware source cache)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ There is no installer and no build step for the package itself — `CMakeLists.i
    include(${teensy_cmake_macros_SOURCE_DIR}/CMakeLists.include.txt)
    ```
    They then call the macros from their own `CMakeLists.txt`, configured with a Teensy toolchain file.
-2. **The macros file fetches the Teensy 4 core itself.** On `include()` it `FetchContent`s `PaulStoffregen/cores` and defaults `COREPATH` to `${teensy_cores_SOURCE_DIR}/teensy4/`. Consumers do not have to clone the core. Individual Arduino libraries are fetched per-library (see `import_arduino_library_git`).
+2. **The macros file fetches the Teensy 4 core itself.** On `include()` it `FetchContent`s `newdigate/teensy-cores` (a fork of `PaulStoffregen/cores` that adds the RT1060-EVKB board) and defaults `COREPATH` to `${teensy_cores_SOURCE_DIR}/teensy4/`. Consumers do not have to clone the core. Individual Arduino libraries are fetched per-library (see `import_arduino_library_git`).
 
 **Critical workflow consequence:** consumers pin `GIT_TAG main`, so they fetch the macros from GitHub, *not* from your local working tree. To test local edits to `CMakeLists.include.txt` against a consumer build, redirect FetchContent at your checkout:
 ```shell
@@ -34,21 +34,21 @@ Otherwise your changes are only seen after they are pushed to `main`.
 
 ### The macros (all defined in `CMakeLists.include.txt`)
 
-- `teensy_set_dynamic_properties()` — builds the compile/link flag strings from `TEENSY_VERSION` (40 or 41), `CPU_CORE_SPEED`, `COMPILERPATH`, `COREPATH`. Runs once per configure (guarded by a cache variable). FATAL if `CPU_CORE_SPEED` or `COMPILERPATH` is unset, or `TEENSY_VERSION` is not 40/41. Hardcodes `TEENSYDUINO=159`, `ARDUINO=10607`, `-std=gnu++17`, `-fno-exceptions -fno-rtti`. Called automatically by `teensy_add_executable`/`teensy_add_library`.
+- `teensy_set_dynamic_properties()` — builds the compile/link flag strings from `TEENSY_VERSION` (40, 41, or 42), `CPU_CORE_SPEED`, `COMPILERPATH`, `COREPATH`. Runs once per configure (guarded by a per-configure **global property**, not a cache variable — so a configure that FATALs partway re-runs cleanly next time instead of caching a half-done state and silently skipping the recompute). FATAL if `CPU_CORE_SPEED` or `COMPILERPATH` is unset, or `TEENSY_VERSION` is not 40/41/42. Hardcodes `TEENSYDUINO=159`, `ARDUINO=10607`, `-std=gnu++17`, `-fno-exceptions -fno-rtti`. Called automatically by `teensy_add_executable`/`teensy_add_library`.
 - `import_teensy_cores()` — globs the core `.c/.cpp` under `COREPATH`, stamps the right compile flags on each, and returns them in `TEENSY_SOURCES`. Optional: `teensy_add_library` folds `TEENSY_SOURCES` into every library, so calling this compiles the core into your libs instead of linking it as a separate `cores.o`. The tests don't use it — they build the core as a library via `import_arduino_library(cores ...)`.
 - `teensy_add_executable(TARGET srcs...)` — creates target **`TARGET.elf`** plus a `TARGET_hex` custom target that runs `arm-none-eabi-objcopy` to emit `TARGET.hex`. Accepts `.cpp` and `.ino` (compiled as C++). Only the listed sources go into the elf; the core and libraries are linked in separately via `teensy_target_link_libraries`.
 - `teensy_add_library(TARGET srcs...)` — creates a STATIC library target named **`TARGET.o`** (the `.o` suffix is part of the CMake target name, not a file). A library with no sources (header-only) is skipped with a warning.
 - `import_arduino_library(NAME ROOT [subdirs...])` — globs `.cpp/.c/.S` from a **local** `ROOT` (and each listed subdir), adds include dirs, and calls `teensy_add_library(NAME ...)`. Idempotent (tracked in `Arduino_libraries_List`). Missing `ROOT` is a warning (ignored); a missing named subdir is a fatal error.
-- `import_arduino_library_git(NAME URL BRANCH PATH)` — `FetchContent_Populate`s a library from a git URL, then imports it via `import_arduino_library` from `<fetched>/PATH` (e.g. `PATH=src`, or `""` for the repo root). This is how the tests pull in `SPI`, `ST7735_t3`, etc.
+- `import_arduino_library_git(NAME URL BRANCH PATH [subdirs...])` — fetches a library from a git URL via **CPM.cmake** (`CPMAddPackage(... DOWNLOAD_ONLY YES)`; CPM is bootstrapped lazily on first use — pinned version + SHA256 — so projects that only call `import_arduino_library` never download it), then imports it via `import_arduino_library` from `<fetched>/PATH` (e.g. `PATH=src`, or `""` for the repo root). Set the `CPM_SOURCE_CACHE` env var to clone each `(repo, branch)` once and share it across all projects/build dirs (otherwise CPM clones per build dir, like plain FetchContent). This is how the tests pull in `SPI`, `SD`, `Audio`, etc.
 - `teensy_target_link_libraries(TARGET libs...)` — links each `lib.o` into `TARGET.elf`, **wrapped in a linker group** (`$<LINK_GROUP:RESCAN,...>` → `--start-group/--end-group`). The linker re-scans the group until every cross-reference resolves, so **the order you list libraries does not matter** (circular deps included). The `RESCAN` feature is defined in this file because CMake does not predefine it for `CMAKE_SYSTEM_NAME Generic`.
-- `teensy_include_directories(paths...)` / `teensy_remove_sources(dir)`.
+- `teensy_include_directories(paths...)`.
 - `idf_component_register()` — a no-op stub so the file can be `include()`d from an ESP-IDF component context without error.
 
 Include dirs are threaded through the macros as a single accumulated `-I...` string in the `INCLUDE_DIRECTORIES` variable, not via normal CMake target includes.
 
 ## Required variables (set in the consumer toolchain file)
 
-`TEENSY_VERSION` (40 or 41), `CPU_CORE_SPEED`, `COMPILERPATH` (arm-none-eabi bin dir, trailing slash). `COREPATH` defaults to the fetched core and only needs overriding if you supply your own. Two example toolchain files exist, both hardcoding `COMPILERPATH` (edit for your machine):
+`TEENSY_VERSION` (40, 41, or 42 for the RT1060-EVKB), `CPU_CORE_SPEED`, `COMPILERPATH` (arm-none-eabi bin dir, trailing slash). `COREPATH` defaults to the fetched core and only needs overriding if you supply your own. Two example toolchain files exist, both hardcoding `COMPILERPATH` (edit for your machine):
 
 - `cmake/toolchain/teensy41.toolchain.cmake` — `--specs=nano.specs` (links the C++ std lib); `COMPILERPATH=/Applications/ARM_10/bin/`. Used by `tests/st7735/build.sh`.
 - `tests/teensy41.toolchain.cmake` — `--specs=nosys.specs`, plus a legacy `DEPSPATH` for the local-clone (`import_arduino_library`) workflow.
@@ -77,4 +77,4 @@ GitHub Actions has one workflow per test in `.github/workflows/` (`audio-test`, 
 
 ## Runtime dependencies
 
-Consumer firmware needs the Teensy 4 core (fetched automatically) plus whatever PaulStoffregen Arduino libraries the sketch uses — pulled in per-library with `import_arduino_library_git` (from a git URL) or `import_arduino_library` (from a local path). Commonly: `Audio`, `SD` (branch `Juse_Use_SdFat`), `Wire`, `SPI`, `SerialFlash`, `arm_math`, `greiman/SdFat`. See each test's `CMakeLists.txt` for the exact repo/branch it uses.
+Consumer firmware needs the Teensy 4 core (fetched automatically) plus whatever PaulStoffregen Arduino libraries the sketch uses — pulled in per-library with `import_arduino_library_git` (from a git URL) or `import_arduino_library` (from a local path). Commonly: `Audio`, `SD` (branch `Juse_Use_SdFat`), `Wire`, `SPI`, `SerialFlash`, `arm_math`, `greiman/SdFat`. See each test's `CMakeLists.txt` for the exact repo/branch it uses. These git libraries are fetched via CPM.cmake; set the `CPM_SOURCE_CACHE` env var (e.g. `~/.cache/CPM`) to share one clone of each `(repo, branch)` across all projects and build dirs instead of re-cloning per build dir.

--- a/CMakeLists.include.txt
+++ b/CMakeLists.include.txt
@@ -381,21 +381,51 @@ macro(teensy_target_link_libraries TARGET)
     target_link_libraries(${TARGET}.elf "$<LINK_GROUP:RESCAN,${grouped_libs}>")
 endmacro(teensy_target_link_libraries)
 
+# Bootstrap CPM.cmake (https://github.com/cpm-cmake/CPM.cmake) on first use. CPM is a thin
+# wrapper over FetchContent that adds a shared, tag-aware source cache: set the environment
+# variable CPM_SOURCE_CACHE to a stable path (e.g. ~/.cache/CPM) and each (repo, tag) is
+# cloned once and reused across every project and build directory, instead of FetchContent's
+# per-build-dir clone. Lazy: consumers that only use import_arduino_library (local paths)
+# never download CPM.
+macro(_teensy_bootstrap_cpm)
+    if(NOT COMMAND CPMAddPackage)
+        set(_cpm_version 0.42.3)
+        set(_cpm_sha256 a609e875fd532b067174250f6abbc3dac22fe2d64869783fb1e80bda1625c844)
+        if(DEFINED ENV{CPM_SOURCE_CACHE})
+            set(_cpm_file "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${_cpm_version}.cmake")
+        else()
+            set(_cpm_file "${CMAKE_BINARY_DIR}/cmake/CPM_${_cpm_version}.cmake")
+        endif()
+        if(NOT EXISTS "${_cpm_file}")
+            message(STATUS "Downloading CPM.cmake v${_cpm_version}")
+            file(DOWNLOAD
+                "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${_cpm_version}/CPM.cmake"
+                "${_cpm_file}"
+                EXPECTED_HASH SHA256=${_cpm_sha256})
+        endif()
+        include("${_cpm_file}")
+    endif()
+endmacro()
+
 macro(import_arduino_library_git LIB_NAME LIB_URL LIB_BRANCH LIB_PATH)
-    include(FetchContent)
-    # Fetch sources only: these Arduino libraries are compiled directly with the Teensy
-    # board flags by import_arduino_library, never via their own build system. Point
-    # SOURCE_SUBDIR at a non-existent directory so FetchContent_MakeAvailable populates
-    # without calling add_subdirectory() on the library. (Single-argument
-    # FetchContent_Populate() is deprecated since CMake 3.30 / policy CMP0169.)
-    FetchContent_Declare(${LIB_NAME}
-            GIT_REPOSITORY ${LIB_URL}
-            GIT_TAG        ${LIB_BRANCH}
-            SOURCE_SUBDIR  do_not_add_subdirectory
+    _teensy_bootstrap_cpm()
+    # Fetch sources only (DOWNLOAD_ONLY): the library is compiled with the Teensy board flags
+    # by import_arduino_library, not via its own build system. With CPM_SOURCE_CACHE set, each
+    # (repo, tag) is cloned once and shared across all projects and build directories.
+    CPMAddPackage(
+        NAME           ${LIB_NAME}
+        GIT_REPOSITORY ${LIB_URL}
+        GIT_TAG        ${LIB_BRANCH}
+        DOWNLOAD_ONLY  YES
     )
-    FetchContent_MakeAvailable(${LIB_NAME})
-    string(TOLOWER ${LIB_NAME} LIB_NAME_LOWER)
-    set(LIB_ROOT "${${LIB_NAME_LOWER}_SOURCE_DIR}/${LIB_PATH}")
+    # CPM exports <NAME>_SOURCE_DIR (original case); fall back to the lower-case FetchContent
+    # form just in case.
+    if(DEFINED ${LIB_NAME}_SOURCE_DIR)
+        set(LIB_ROOT "${${LIB_NAME}_SOURCE_DIR}/${LIB_PATH}")
+    else()
+        string(TOLOWER ${LIB_NAME} LIB_NAME_LOWER)
+        set(LIB_ROOT "${${LIB_NAME_LOWER}_SOURCE_DIR}/${LIB_PATH}")
+    endif()
 
     # Check if we can find the library.
     if(NOT EXISTS "${LIB_ROOT}")

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@
    teensy_include_directories(../../src)
  ```
 
+# dependency caching (```CPM_SOURCE_CACHE```)
+Git libraries (```import_arduino_library_git```) are fetched with [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake), bootstrapped automatically on first use (projects that only use ```import_arduino_library``` with local paths never download it). By default each project clones its own copy into its build directory. Set the ```CPM_SOURCE_CACHE``` environment variable to a stable path to clone each ```(repo, branch)``` **once** and share it across all of your projects and build directories:
+```shell
+export CPM_SOURCE_CACHE=$HOME/.cache/CPM
+```
+The cache is keyed by repo + branch, so different branches of the same library coexist without clobbering each other, while identical pins are downloaded only once.
+
 ## used in
 * [midi-smf-reader](https://github.com/newdigate/midi-smf-reader)
 * [teensy-quencer](https://github.com/newdigate/teensy-quencer)


### PR DESCRIPTION
## What

`import_arduino_library_git` now fetches git libraries via [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) (a thin wrapper over `FetchContent`) instead of raw `FetchContent`. With the `CPM_SOURCE_CACHE` environment variable set, each `(repo, branch)` is cloned **once** and shared across all projects and build directories — eliminating `FetchContent`'s per-build-dir duplication while keeping per-project git repo/branch pinning.

## Why

Each consumer project previously re-cloned every library into its own `build/_deps/`, so the same `PaulStoffregen/SPI` (etc.) was duplicated across `blink`, `spi`, `audio`, … CPM's cache is keyed by a repo+branch hash, so identical pins are downloaded once, while different branches of the same library coexist without clobbering each other.

## How

- **Lazy bootstrap** of CPM (pinned `v0.42.3` + SHA256 integrity check) on first use only. Projects that use only `import_arduino_library` (local paths, e.g. `blink`) never download CPM.
- `CPMAddPackage(... DOWNLOAD_ONLY YES)` — fetch-only; libraries are still compiled with the Teensy board flags by `import_arduino_library`, not via their own build system.
- **Consumer API unchanged:** `import_arduino_library_git(NAME URL BRANCH PATH [subdirs...])`.

## Verified

- Two **separate** projects both pinning `SPI@master` and sharing one `CPM_SOURCE_CACHE` → exactly **one** SPI clone (project 1 logs "…to …/spi/1d9f", project 2 logs "…at …/spi/1d9f"); neither build dir has its own clone.
- `tests/spi` builds end-to-end from the cached source → `spiapp.elf` / `.hex`.
- `blink` (uses only `import_arduino_library`) builds → `blinky.hex` with **zero** CPM downloads — lazy bootstrap confirmed.

## Usage

```shell
export CPM_SOURCE_CACHE=$HOME/.cache/CPM
```

Without it, behaviour is per-build-dir (safe default). Docs (`README.md` + `CLAUDE.md`) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
