### PR TITLE
Improve README readability; fix stale doc references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Otherwise your changes are only seen after they are pushed to `main`.
 
 - `teensy_set_dynamic_properties()` — builds the per-language compile flags and link flags from `TEENSY_VERSION` (40, 41, or 42), `CPU_CORE_SPEED`, `COMPILERPATH`, `COREPATH` and hangs them on a single `teensy_flags` **INTERFACE** target (compile options via `$<COMPILE_LANGUAGE:…>` genexprs, include dirs via `target_include_directories`) that every `teensy_add_*`/imported library links — so flags propagate as CMake usage requirements instead of being stamped onto each source. Runs once per configure; the guard is just `if(NOT TARGET teensy_flags)`, which self-resets each configure (no cache var or global property that a half-done run could poison). FATAL if `CPU_CORE_SPEED` or `COMPILERPATH` is unset, or `TEENSY_VERSION` is not 40/41/42. Hardcodes `TEENSYDUINO=159`, `ARDUINO=10607`, `-std=gnu++17`, `-fno-exceptions -fno-rtti`. Called automatically by `teensy_add_executable`/`teensy_add_library`.
 - `import_teensy_cores()` — globs the core `.c/.cpp` under `COREPATH` and returns them in `TEENSY_SOURCES` (they pick up the flags from `teensy_flags` once a library folds them in). Optional: `teensy_add_library` folds `TEENSY_SOURCES` into every library, so calling this compiles the core into your libs instead of linking it as a separate `cores.o`. The tests don't use it — they build the core as a library via `import_arduino_library(cores ...)`.
-- `teensy_add_executable(TARGET srcs...)` — creates target **`TARGET.elf`** plus a `TARGET_hex` custom target that runs `arm-none-eabi-objcopy` to emit `TARGET.hex`. Accepts `.cpp` and `.ino` (compiled as C++). Only the listed sources go into the elf; the core and libraries are linked in separately via `teensy_target_link_libraries`.
+- `teensy_add_executable(TARGET srcs...)` — creates target **`TARGET.elf`** plus a `TARGET_hex` custom target that runs `arm-none-eabi-objcopy` to emit `TARGET.hex`. Accepts `.ino`/`.cpp` (compiled as C++) and `.c`. Only the listed sources go into the elf; the core and libraries are linked in separately via `teensy_target_link_libraries`.
 - `teensy_add_library(TARGET srcs...)` — creates a STATIC library target named **`TARGET.o`** (the `.o` suffix is part of the CMake target name, not a file). A library with no sources (header-only) is skipped with a warning.
 - `import_arduino_library(NAME ROOT [subdirs...])` — globs `.cpp/.c/.S` from a **local** `ROOT` (and each listed subdir), adds include dirs, and calls `teensy_add_library(NAME ...)`. Idempotent (tracked in `Arduino_libraries_List`). Missing `ROOT` is a warning (ignored); a missing named subdir is a fatal error.
 - `import_arduino_library_git(NAME URL BRANCH PATH [subdirs...])` — fetches a library from a git URL via **CPM.cmake** (`CPMAddPackage(... DOWNLOAD_ONLY YES)`; CPM is bootstrapped lazily on first use — pinned version + SHA256 — so projects that only call `import_arduino_library` never download it), then imports it via `import_arduino_library` from `<fetched>/PATH` (e.g. `PATH=src`, or `""` for the repo root). Set the `CPM_SOURCE_CACHE` env var to clone each `(repo, branch)` once and share it across all projects/build dirs (otherwise CPM clones per build dir, like plain FetchContent). This is how the tests pull in `SPI`, `SD`, `Audio`, etc.
@@ -48,20 +48,19 @@ Compile flags and include dirs are carried on a single `teensy_flags` `INTERFACE
 
 ## Required variables (set in the consumer toolchain file)
 
-`TEENSY_VERSION` (40, 41, or 42 for the RT1060-EVKB), `CPU_CORE_SPEED`, `COMPILERPATH` (arm-none-eabi bin dir, trailing slash). `COREPATH` defaults to the fetched core and only needs overriding if you supply your own. Two example toolchain files exist, both hardcoding `COMPILERPATH` (edit for your machine):
+`TEENSY_VERSION` (40, 41, or 42 for the RT1060-EVKB), `CPU_CORE_SPEED`, `COMPILERPATH` (arm-none-eabi bin dir, trailing slash). `COREPATH` defaults to the fetched core and only needs overriding if you supply your own. Consumers normally write their own toolchain file (see the README quick-start); the repo ships one example:
 
-- `cmake/toolchain/teensy41.toolchain.cmake` — `--specs=nano.specs` (links the C++ std lib); `COMPILERPATH=/Applications/ARM_10/bin/`. Used by `tests/st7735/build.sh`.
-- `tests/teensy41.toolchain.cmake` — `--specs=nosys.specs`, plus a legacy `DEPSPATH` for the local-clone (`import_arduino_library`) workflow.
+- `tests/teensy41.toolchain.cmake` — `TEENSY_VERSION 41`, `--specs=nosys.specs`, `COMPILERPATH` hardcoded to the CI path `/opt/gcc-arm-none-eabi-9-2019-q4-major/bin/` (a macOS `/Applications/ARM/bin/` alternative is commented out). Edit `COMPILERPATH` for your machine.
 
 ## Build commands
 
-Nothing to install. Build a test/consumer project by configuring it with a Teensy toolchain file, then `make`. Example (`tests/st7735`, which has a `build.sh`):
+Nothing to install. Build a test/consumer project by configuring it with a Teensy toolchain file, then `make`. Example (`tests/spi`):
 
 ```shell
-cd tests/st7735
+cd tests/spi
 mkdir -p cmake-build-debug && cd cmake-build-debug
 cmake -DCMAKE_BUILD_TYPE=Debug \
-      -DCMAKE_TOOLCHAIN_FILE:FILEPATH=../../../cmake/toolchain/teensy41.toolchain.cmake ..
+      -DCMAKE_TOOLCHAIN_FILE:FILEPATH=../../teensy41.toolchain.cmake ..
 make
 ```
 
@@ -69,9 +68,9 @@ To exercise local macro edits, add `-DFETCHCONTENT_SOURCE_DIR_TEENSY_CMAKE_MACRO
 
 ## Tests & CI
 
-Each subdir of `tests/` (`basic`, `spi`, `audio`, `eeprom`, `vector`, `st7735`) is an independent consumer project with its own `CMakeLists.txt`, exercising a different dependency set; each fetches the macros, the core, and its libraries via `FetchContent`.
+Each subdir of `tests/` (`basic`, `spi`, `audio`, `eeprom`, `vector`) is an independent consumer project with its own `CMakeLists.txt`, exercising a different dependency set; each fetches the macros, the core, and its libraries via `FetchContent`.
 
-GitHub Actions has one workflow per test in `.github/workflows/` (`audio-test`, `basic-test`, `eeprom-test`, `spi-test`, `vector` — there is no `st7735` workflow yet). Each checks out the repo, downloads the ARM 9-2019-q4 toolchain to `/opt`, then configures+builds that one test with a toolchain file. Dependencies come from `FetchContent`, not a manual `deps/` clone.
+GitHub Actions has one workflow per test in `.github/workflows/` (`audio-test`, `basic-test`, `eeprom-test`, `spi-test`, `vector`). Each checks out the repo, downloads the ARM 9-2019-q4 toolchain to `/opt`, then configures+builds that one test with a toolchain file. Dependencies come from `FetchContent`, not a manual `deps/` clone.
 
 `tests/vector` is the reference for linking the C++ std library: set `CMAKE_EXE_LINKER_FLAGS "--specs=nano.specs"` and `target_link_libraries(<target>.elf stdc++)` (note the `.elf` suffix and raw `target_link_libraries`, not the `teensy_` wrapper).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# teensy cmake macros 
+# teensy cmake macros
 
 [![audio-test](https://github.com/newdigate/teensy-cmake-macros/actions/workflows/audio-test.yml/badge.svg)](https://github.com/newdigate/teensy-cmake-macros/actions/workflows/audio-test.yml)
 [![basic-test](https://github.com/newdigate/teensy-cmake-macros/actions/workflows/basic-test.yml/badge.svg)](https://github.com/newdigate/teensy-cmake-macros/actions/workflows/basic-test.yml)
@@ -6,129 +6,125 @@
 [![eeprom-test](https://github.com/newdigate/teensy-cmake-macros/actions/workflows/eeprom-test.yml/badge.svg)](https://github.com/newdigate/teensy-cmake-macros/actions/workflows/eeprom-test.yml)
 [![spi-test](https://github.com/newdigate/teensy-cmake-macros/actions/workflows/spi-test.yml/badge.svg)](https://github.com/newdigate/teensy-cmake-macros/actions/workflows/spi-test.yml)
 
- A minimal dependency cmake toolchain to easily compile your teensy sketches and libraries, and optionally link with c++ std libraries. 
-* custom teensy toolchain using ```cmake``` and ```arm-none-eabi-gcc```
-* based on [ronj/teensy-cmake-template](https://github.com/ronj/teensy-cmake-template)
-* targetting Teensy 4.x, tested on Teensy 4.1 (should be easy to extend for 3.x)
-* compiles library code to .a archive files to avoid unnecessary recompiling
+A minimal CMake toolchain + macros for cross-compiling **Teensy 4.x** firmware and libraries with `arm-none-eabi-gcc` — no Arduino IDE required.
 
-#  build dependencies
- * [arm-none-eabi-gcc](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
- * [cmake](https://cmake.org/)
+- builds with `cmake` + `arm-none-eabi-gcc`
+- Teensy 4.0 / 4.1 (tested on 4.1) and the NXP **RT1060-EVKB** dev board; should be easy to extend to 3.x
+- pulls Arduino libraries straight from git, with an optional shared cache (see [Dependency caching](#dependency-caching))
+- compiles library code to `.a` archives to avoid unnecessary recompiles, and can link the C++ std library
+- based on [ronj/teensy-cmake-template](https://github.com/ronj/teensy-cmake-template)
 
-# add CMakeLists.txt to your project root
-  * add a toolchain cmake file `cmake\toolchains\teensy41.cmake`
-    * update ```COMPILERPATH``` to [arm-none-eabi-gcc](https://developer.arm.com/downloads/-/gnu-rm/10-3-2021-10) bin folder
-    ```cmake
-    set(TEENSY_VERSION 42 CACHE STRING "Set to the Teensy version corresponding to your board (40 or 41, 42 (RT1060-EVKB) allowed)" FORCE)
-    set(CPU_CORE_SPEED 600000000 CACHE STRING "Set to 24000000, 48000000, 72000000 or 96000000 to set CPU core speed" FORCE) # Derived variables
-    set(CMAKE_EXE_LINKER_FLAGS "--specs=nano.specs" CACHE INTERNAL "") # if you plan on using std 
-    set(COMPILERPATH "/Applications/ARM_10/bin/")
-    set(CMAKE_SYSTEM_NAME Generic)
-    set(CMAKE_SYSTEM_PROCESSOR arm)
-    set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
-    set(CMAKE_C_COMPILER ${COMPILERPATH}arm-none-eabi-gcc)
-    set(CMAKE_CXX_COMPILER ${COMPILERPATH}arm-none-eabi-g++)
-    set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_C_COMPILER} <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-    ```
+## Requirements
 
-  * create a ```CMakeLists.txt``` file in the root directory of your project
-  ```cmake
-    cmake_minimum_required(VERSION 3.5)
-    project(midi_smf_reader C CXX)
+- [arm-none-eabi-gcc](https://developer.arm.com/downloads/-/gnu-rm)
+- [CMake](https://cmake.org/) ≥ 3.24 — the macros use the `$<LINK_GROUP>` generator expression
 
-    include(FetchContent)
-    FetchContent_Declare(teensy_cmake_macros
-            GIT_REPOSITORY https://github.com/newdigate/teensy-cmake-macros
-            GIT_TAG        main
-    )
-    FetchContent_MakeAvailable(teensy_cmake_macros)
-    include(${teensy_cmake_macros_SOURCE_DIR}/CMakeLists.include.txt)
+## Quick start
 
-    import_arduino_library(cores ${teensy_cores_SOURCE_DIR}/teensy4 avr util)
-    
-    import_arduino_library_git(SPI https://github.com/PaulStoffregen/SPI.git master "")
-    import_arduino_library_git(SdFat https://github.com/PaulStoffregen/SdFat.git master "src" common DigitalIO ExFatLib FatLib FsLib iostream SdCard SpiDriver)
-    import_arduino_library_git(SD https://github.com/PaulStoffregen/SD.git Juse_Use_SdFat src)
-    import_arduino_library_git(Encoder https://github.com/PaulStoffregen/Encoder.git master "")
-    import_arduino_library_git(Bounce2 https://github.com/PaulStoffregen/Bounce2.git master src)
-    import_arduino_library_git(SerialFlash https://github.com/PaulStoffregen/SerialFlash.git master "" util)
-    import_arduino_library_git(Wire https://github.com/PaulStoffregen/Wire.git master "" utility)
-    import_arduino_library_git(arm_math https://github.com/PaulStoffregen/arm_math.git master src)
-    import_arduino_library_git(TeensyGFX https://github.com/newdigate/teensy-gfx.git main src)
+### 1. Toolchain file
 
-    # add custom library
-    teensy_add_library(my_teensy_library my_teensy_library.cpp)
+Create `cmake/toolchain/teensy41.cmake` and point `COMPILERPATH` at your `arm-none-eabi-gcc` `bin/` folder:
 
-    # add custom executable
-    teensy_add_executable(my_firmware sketch.ino)
-    teensy_target_link_libraries(my_firmware my_teensy_library SD SdFat SPI cores) # order is IMPORTANT because we are garbage collecting symbols --gc-collect
-    
-    # if you need to link to std library (using <Vector>, etc) 
-    set(CMAKE_EXE_LINKER_FLAGS "--specs=nano.specs" CACHE INTERNAL "")
-    target_link_libraries(my_firmware.elf stdc++)
-  ```
+```cmake
+set(TEENSY_VERSION 41 CACHE STRING "Teensy version: 40, 41, or 42 (RT1060-EVKB)" FORCE)
+set(CPU_CORE_SPEED 600000000 CACHE STRING "CPU core speed in Hz" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS "--specs=nano.specs" CACHE INTERNAL "")   # needed if you link the C++ std lib
+set(COMPILERPATH "/Applications/ARM_10/bin/")                        # <-- edit for your machine
 
-# build
-  * run from a terminal in your repository root directory 
-  ```shell
-  > mkdir cmake-build-debug
-  > cd cmake-build-debug
-  > cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE:FILEPATH="../cmake/toolchains/teensy41.toolchain.cmake" 
-  > make       
-  ```
-
-# detail 
-* ```teensy_add_executable``` ( ```TARGET``` ```files...``` )
-  ```cmake 
-  teensy_add_executable(myapplication midiread.cpp)
-  ``` 
-* ```teensy_add_library``` ( ```TARGET``` ```files...``` )
-  ```cmake 
-  teensy_add_library(mylibrary library1.cpp)
-  ``` 
-  
-* ```import_arduino_library``` ( ```LibraryName``` ```LibraryPath``` ```additionalRelativeSourceFolders```)
-  ```cmake 
-  import_arduino_library(cores ${COREPATH} avr util)
-  import_arduino_library(SPI ${DEPSPATH}/SPI)        # SPI@Juse_Use_SdFat
-  import_arduino_library(SdFat ${DEPSPATH}/SdFat/src common DigitalIO ExFatLib FatLib FsLib iostream SdCard SpiDriver)
-  import_arduino_library(SD ${DEPSPATH}/SD/src)  
-  ```
-* ```teensy_target_link_libraries``` ( ```TARGET``` ```libraries...```) 
-```
-  teensy_target_link_libraries(my_firmware mylibrary SD SdFat SPI cores)
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+set(CMAKE_C_COMPILER   ${COMPILERPATH}arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER ${COMPILERPATH}arm-none-eabi-g++)
+set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_C_COMPILER} <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
 ```
 
-* ```import_arduino_library_git``` ( ```LibraryName``` ```LibraryUrl``` ```Branch``` ```SourcePath``` ```additionalRelativeSourceFolders```)
-  ```cmake 
-    import_arduino_library_git(SPI https://github.com/PaulStoffregen/SPI.git master "")
-    import_arduino_library_git(SdFat https://github.com/PaulStoffregen/SdFat.git master "src" common DigitalIO ExFatLib FatLib FsLib iostream SdCard SpiDriver)
-    import_arduino_library_git(SD https://github.com/PaulStoffregen/SD.git Juse_Use_SdFat src)
-    import_arduino_library_git(Encoder https://github.com/PaulStoffregen/Encoder.git master "")
-    import_arduino_library_git(Bounce2 https://github.com/PaulStoffregen/Bounce2.git master src)
-    import_arduino_library_git(SerialFlash https://github.com/PaulStoffregen/SerialFlash.git master "" util)
-    import_arduino_library_git(Wire https://github.com/PaulStoffregen/Wire.git master "" utility)
-    import_arduino_library_git(arm_math https://github.com/PaulStoffregen/arm_math.git master src)
-    import_arduino_library_git(TeensyGFX https://github.com/newdigate/teensy-gfx.git main src)
-  ```
-* link to std library
-``` 
-   set(CMAKE_EXE_LINKER_FLAGS "--specs=nano.specs" CACHE INTERNAL "")
-   target_link_libraries(my_firmware.elf stdc++)
-```
- * ```teensy_include_directories``` ( ```paths...```)
- ``` 
-   teensy_include_directories(../../src)
- ```
+### 2. `CMakeLists.txt`
 
-# dependency caching (```CPM_SOURCE_CACHE```)
-Git libraries (```import_arduino_library_git```) are fetched with [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake), bootstrapped automatically on first use (projects that only use ```import_arduino_library``` with local paths never download it). By default each project clones its own copy into its build directory. Set the ```CPM_SOURCE_CACHE``` environment variable to a stable path to clone each ```(repo, branch)``` **once** and share it across all of your projects and build directories:
+The macros — and the Teensy 4 core — are pulled in with `FetchContent`; you don't clone anything by hand:
+
+```cmake
+cmake_minimum_required(VERSION 3.24)
+project(my_firmware C CXX)
+
+include(FetchContent)
+FetchContent_Declare(teensy_cmake_macros
+        GIT_REPOSITORY https://github.com/newdigate/teensy-cmake-macros
+        GIT_TAG        main)
+FetchContent_MakeAvailable(teensy_cmake_macros)
+include(${teensy_cmake_macros_SOURCE_DIR}/CMakeLists.include.txt)
+
+# the Teensy 4 core (fetched automatically into ${teensy_cores_SOURCE_DIR})
+import_arduino_library(cores ${teensy_cores_SOURCE_DIR}/teensy4 avr util)
+
+# Arduino libraries, straight from git (see "Dependency caching" below)
+import_arduino_library_git(SPI https://github.com/PaulStoffregen/SPI.git master "")
+
+# your own code
+teensy_add_library(my_lib my_lib.cpp)                       # optional
+teensy_add_executable(my_firmware sketch.ino)               # .ino, .cpp and .c all work
+teensy_target_link_libraries(my_firmware my_lib SPI cores)  # link order does not matter
+```
+
+### 3. Build
+
+```shell
+mkdir build && cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/teensy41.cmake
+make
+```
+
+You get `my_firmware.elf` and `my_firmware.hex`, ready to flash. A passing build means it compiles and links — there is no on-device check.
+
+## Macros
+
+| macro | what it does |
+|---|---|
+| `teensy_add_executable(TARGET srcs…)` | builds `TARGET.elf` and a `TARGET.hex`. Sources may be `.ino`/`.cpp` (compiled as C++) or `.c`. |
+| `teensy_add_library(TARGET srcs…)` | builds a static library, target named `TARGET.o`. |
+| `import_arduino_library(NAME ROOT [subdirs…])` | adds a library from a **local** path and builds it. |
+| `import_arduino_library_git(NAME URL BRANCH PATH [subdirs…])` | fetches a library from **git** (via CPM) and builds it. `PATH` is the source subdir (`""` = repo root); extra `subdirs` are added as well. |
+| `teensy_target_link_libraries(TARGET libs…)` | links libraries into `TARGET.elf`. **Order does not matter** — the libraries are wrapped in a linker group that re-scans until every cross-reference resolves (circular deps included). |
+| `teensy_include_directories(paths…)` | adds extra include directories. |
+
+<details>
+<summary>Example: common PaulStoffregen libraries (repo / branch / source path)</summary>
+
+```cmake
+import_arduino_library_git(SPI         https://github.com/PaulStoffregen/SPI.git         master "")
+import_arduino_library_git(SdFat       https://github.com/PaulStoffregen/SdFat.git       master "src" common DigitalIO ExFatLib FatLib FsLib iostream SdCard SpiDriver)
+import_arduino_library_git(SD          https://github.com/PaulStoffregen/SD.git          Juse_Use_SdFat src)
+import_arduino_library_git(Encoder     https://github.com/PaulStoffregen/Encoder.git     master "")
+import_arduino_library_git(Bounce2     https://github.com/PaulStoffregen/Bounce2.git     master src)
+import_arduino_library_git(SerialFlash https://github.com/PaulStoffregen/SerialFlash.git master "" util)
+import_arduino_library_git(Wire        https://github.com/PaulStoffregen/Wire.git        master "" utility)
+import_arduino_library_git(arm_math    https://github.com/PaulStoffregen/arm_math.git    master src)
+import_arduino_library_git(TeensyGFX   https://github.com/newdigate/teensy-gfx.git       main src)
+```
+</details>
+
+## Dependency caching
+
+Git libraries (`import_arduino_library_git`) are fetched with [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake), bootstrapped automatically the first time you use one. By default each build directory clones its own copy. Set the `CPM_SOURCE_CACHE` environment variable to clone each `(repo, branch)` **once** and share it across every project and build directory:
+
 ```shell
 export CPM_SOURCE_CACHE=$HOME/.cache/CPM
 ```
-The cache is keyed by repo + branch, so different branches of the same library coexist without clobbering each other, while identical pins are downloaded only once.
 
-## used in
+The cache is keyed by repo + branch, so different branches of the same library coexist without clobbering each other, while identical pins are downloaded only once. Projects that use only `import_arduino_library` (local paths) never download CPM.
+
+## Linking the C++ standard library
+
+If your sketch uses `<vector>`, `<string>`, and friends:
+
+```cmake
+set(CMAKE_EXE_LINKER_FLAGS "--specs=nano.specs" CACHE INTERNAL "")
+target_link_libraries(my_firmware.elf stdc++)
+```
+
+Note the `.elf` suffix and the plain `target_link_libraries` (not the `teensy_` wrapper).
+
+## Used in
+
 * [midi-smf-reader](https://github.com/newdigate/midi-smf-reader)
 * [teensy-quencer](https://github.com/newdigate/teensy-quencer)


### PR DESCRIPTION
Documentation only — no code changes.

## README — readability

Restructured into a clear flow and trimmed the cruft:

- **Quick start** in three steps (toolchain file → `CMakeLists.txt` → build) with a *minimal* example, instead of the previous nine-library kitchen sink
- **Macros** are now a scannable table
- the full PaulStoffregen library list is collapsed into one `<details>` block (it was duplicated verbatim in two places)
- **Dependency caching** (`CPM_SOURCE_CACHE`) surfaced as its own section rather than buried at the end

Fixes along the way:
- `cmake_minimum_required(VERSION 3.5)` → **3.24** (the macros need `$<LINK_GROUP>`)
- dropped the `# order is IMPORTANT … --gc-collect` comment — it contradicts the RESCAN linker group, which makes link order irrelevant
- noted that `teensy_add_executable` also accepts `.c`

Badges, the upstream credit, and the "used in" links are preserved.

## CLAUDE.md — accuracy

- replaced references to the non-existent `tests/st7735` and `cmake/toolchain/teensy41.toolchain.cmake` with the real `tests/spi` + `tests/teensy41.toolchain.cmake`
- removed `st7735` from the test and workflow lists
- `teensy_add_executable` documented as accepting `.c` as well as `.ino`/`.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
